### PR TITLE
.gitignore: Initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+
+# Debug and Release folder
+Debug/
+Release/


### PR DESCRIPTION
Initial commit of the .gitignore file for eliminating unecessary files from
project commits to the ADICUP360 repository. This commit will ensure that
no files from Debug and Release folder will be uploaded to github. This
folders will be automatically generated once the user builds his project.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>