### PR TITLE
cn0338: add function to fix unhandled char 

### DIFF
--- a/projects/ADuCM360_demo_cn0338/src/Cmd.cpp
+++ b/projects/ADuCM360_demo_cn0338/src/Cmd.cpp
@@ -189,6 +189,29 @@ void CCmdHelp::on_Enter(void)
 }
 
 /**
+   @brief handle ascii characters
+
+   @return none
+**/
+void handle_ascii_data(char c)
+{
+   cmd_buffer[cmd_tail] = c;
+
+   putchar(cmd_buffer[cmd_tail]);
+
+   if (cmd_tail != (CMD_BUFFER_SIZE - 1)) {
+      ++cmd_tail;
+   } else {
+      cmd_tail = 0;
+   }
+
+   if (cmd_tail == cmd_head) {
+      puts("\r\nYou typed too much!\r");
+      printf("Please re-enter: ");
+   }
+}
+
+/**
    @brief Read command
 
    @return none
@@ -196,26 +219,13 @@ void CCmdHelp::on_Enter(void)
 void Cmd_ReadData(void)
 {
    while (uart_rx_head != uart_rx_tail) {
+      char c = uart_rx_queue[uart_rx_head];
+      if (c >= ' ' && c <= '~') {
+         handle_ascii_data(c);
+         continue;
+      }
+
       switch (uart_rx_queue[uart_rx_head]) {
-      case ' ' ... '~':
-         cmd_buffer[cmd_tail] = uart_rx_queue[uart_rx_head];
-
-         putchar(cmd_buffer[cmd_tail]);
-
-         if (cmd_tail != (CMD_BUFFER_SIZE - 1)) {
-            ++cmd_tail;
-
-         } else {
-            cmd_tail = 0;
-         }
-
-         if (cmd_tail == cmd_head) {
-            puts("\r\nYou typed too much!\r");
-            printf("Please re-enter: ");
-         }
-
-         break;
-
       case '\r':
       case '\n':
          puts("\r");


### PR DESCRIPTION
Handle ascii characters in separate function. This addresses an issue with
using cppcheck, where the tool (cppcheck) fails for that specific construct
(i.e. `case ' ' ... '[')`. The issue can be addressed also by fixing the tool,
 but that effort takes a bit longer to finish. The easiest solution in our case
 is to just rewrite that case block into an `if` statement and handle ASCII
 characters separately. This is not a bad idea considering that the
`case ' ' ... '['` statement is not a common practice in general C code.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>