### PR TITLE
general: add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+
+sudo: required
+
+matrix:
+  include:
+    - os: linux
+      env: BUILD_TYPE=astyle
+    - os: linux
+      compiler: gcc
+    - os: linux
+      compiler: clang
+    - os: osx
+      compiler: gcc
+    - os: osx
+      compiler: clang
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./ci/travis/before_install_darwin ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./ci/travis/before_install_linux ; fi
+
+script:
+  - ./ci/scripts/run_build.sh

--- a/ci/scripts/astyle.sh
+++ b/ci/scripts/astyle.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+echo_red() { printf "\033[1;31m$*\033[m\n"; }
+
+COMMIT_RANGE="$1"
+if [ -z "$COMMIT_RANGE"]
+then 
+	COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
+	if [ -z "$TRAVIS_PULL_REQUEST_SHA" ]
+	then
+		echo "Using only latest commit, since there is no Pull Request"
+		COMMIT_RANGE=HEAD~1
+	fi
+fi
+
+FILES=$(git diff --name-only $COMMIT_RANGE)
+
+is_source_file() {
+	local file="$1"
+	local ext_list=".c .h .cpp .hpp"
+
+	for ext in $ext_list; do
+		[[ "${file: -2}" == "$ext" ]] && return 0
+	done;
+
+	return 1
+}
+
+if [ ! -d build/astyle/build/gcc ]
+then	
+	mkdir -p build
+	pushd build
+	wget "https://sourceforge.net/projects/astyle/files/astyle/astyle 3.1/astyle_3.1_linux.tar.gz"
+	tar -xzf astyle_3.1_linux.tar.gz
+	pushd ./astyle/build/gcc
+	make
+	popd
+	popd
+fi
+
+for file in $FILES; do
+	if is_source_file $file
+	then 
+		./build/astyle/build/gcc/bin/astyle --options=./ci/scripts/astyle_config $file
+	fi
+done;
+
+git diff --exit-code || {
+	echo_red "Code style issues found." 
+	exit 1
+}

--- a/ci/scripts/astyle_config
+++ b/ci/scripts/astyle_config
@@ -1,0 +1,3 @@
+--style=linux 
+--indent=force-tab=8 
+--max-code-length=80

--- a/ci/scripts/cppcheck.sh
+++ b/ci/scripts/cppcheck.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+cppcheck --quiet --force --error-exitcode=1 .

--- a/ci/scripts/run_build.sh
+++ b/ci/scripts/run_build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+build_default() {
+    . ./ci/scripts/cppcheck.sh
+}
+
+build_astyle() {
+    . ./ci/scripts/astyle.sh
+}
+
+build_${BUILD_TYPE:-default}

--- a/ci/travis/before_install_darwin
+++ b/ci/travis/before_install_darwin
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+brew update
+
+PACKAGES="cppcheck"
+
+brew_install_or_upgrade() {
+    brew install $1 || \
+            brew upgrade $1 || \
+            brew ls --versions $1 # check if installed last-ly
+}
+
+for package in $PACKAGES ; do
+	brew_install_or_upgrade "$package"
+done

--- a/ci/travis/before_install_linux
+++ b/ci/travis/before_install_linux
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+sudo apt-get update
+sudo apt-get install cppcheck


### PR DESCRIPTION
Add Travis to EVAL-ADICUP360 repo.

The purpose of it is to perform static analysis with the cppcheck tool
on all source files and and check if code style of the files
modified/added per commit correspond to the standards.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>