### PR TITLE
cppcheckignore: add cn0359 application drivers

### DIFF
--- a/.cppcheckignore
+++ b/.cppcheckignore
@@ -13,3 +13,4 @@
 // for further information: https://cppcheck.sourceforge.net/manual.pdf 
 
 *:projects/ADuCM360_demo_blink/IAR/system/*
+*:projects/ADuCM360_demo_cn0359_reva/src/applications/*


### PR DESCRIPTION
Add application drivers to cppcheckignore since the source files are third-party.